### PR TITLE
Remove cached connectionValue when disconnected

### DIFF
--- a/lib/src/windows/bluetooth_device_windows.dart
+++ b/lib/src/windows/bluetooth_device_windows.dart
@@ -134,6 +134,10 @@ class BluetoothDeviceWindows extends FBP.BluetoothDevice {
       log(e.toString());
     } finally {
       log('fbp: remove device from set...');
+      final map = FlutterBluePlusWindows._connectionStream.latestValue;
+      map[_address] = false;              // mark as disconnected in the cache
+      FlutterBluePlusWindows._connectionStream.add(map);
+      log('fbp: remove device from set...');
       FlutterBluePlusWindows._deviceSet.remove(this);
 
       FlutterBluePlusWindows._deviceSubscriptions[remoteId]


### PR DESCRIPTION
## Status

**READY**

## Description

Before disconnecting a device did not clear the cache of a device which lead to a device having connection state "connected" during scanning when an error occured in the previous connection attempt.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
